### PR TITLE
Line 108 and 109 of HumanDetector.cpp were giving colcon build error

### DIFF
--- a/rmf_human_detector/src/HumanDetector.cpp
+++ b/rmf_human_detector/src/HumanDetector.cpp
@@ -105,8 +105,8 @@ HumanDetector::HumanDetector(const rclcpp::NodeOptions& options)
       // perform detections
       auto [rmf_obstacles, image_detections] = _data->_detector->image_cb(msg);
 
-      rmf_obstacles.header.stamp = this->get_clock()->now();
-      rmf_obstacles.header.frame_id = _data->_camera_name;
+      // rmf_obstacles.header.stamp = this->get_clock()->now();
+      // rmf_obstacles.header.frame_id = _data->_camera_name;
 
       // populate fields like time stamp, etc
       for (auto& obstacle : rmf_obstacles.obstacles)


### PR DESCRIPTION
After cloning the rmf_obstacle_detectors and then while building it , HumanDetector.cpp was giving the following errors:
```
error: ‘std::tuple_element<0, std::pair<rmf_obstacle_msgs::msg::Obstacles_<std::allocator<void> >, sensor_msgs::msg::Image_<std::allocator<void> > > >::type’ {aka ‘struct rmf_obstacle_msgs::msg::Obstacles_<std::allocator<void> >’} has no member named ‘header’
  108 |       rmf_obstacles.header.stamp = this->get_clock()->now();
      |                     ^~~~
/home/avisheet/opem-rmf_ws/src/rmf_obstacle_detectors/rmf_human_detector/src/HumanDetector.cpp:109:21: error: ‘std::tuple_element<0, std::pair<rmf_obstacle_msgs::msg::Obstacles_<std::allocator<void> >, sensor_msgs::msg::Image_<std::allocator<void> > > >::type’ {aka ‘struct rmf_obstacle_msgs::msg::Obstacles_<std::allocator<void> >’} has no member named ‘header’
  109 |       rmf_obstacles.header.frame_id = _data->_camera_name;
```